### PR TITLE
[master] fix site publishing script for git 2.9+ 

### DIFF
--- a/pub_jsdoc.sh
+++ b/pub_jsdoc.sh
@@ -10,7 +10,7 @@ git fetch --depth=1 jsdoc gh-pages
 
 git add --all
 git commit -m "jsdoc"
-git merge --no-edit -s ours remotes/jsdoc/gh-pages
+git merge --no-edit -s ours remotes/jsdoc/gh-pages --allow-unrelated-histories
 
 git push jsdoc master:gh-pages
 


### PR DESCRIPTION
http://stackoverflow.com/questions/27641380/git-merge-commits-into-an-orphan-branch/36528527#36528527

> With git 2.9 (June 2016), merging orphan branches is still possible, but ony with the --allow-unrelated-histories option: